### PR TITLE
TRIVIAL update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:11.6-slim
 
 RUN set -ex \
     && apt-get clean && apt-get update \


### PR DESCRIPTION
# What has changed?

Update the source Debian container to Bullseye (v11.6).