### PR TITLE
TRIVIAL add GH action to build the container image in ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - "v*.*.*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TAG: ${{ github.ref_name }}
+
+jobs:
+  release-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker build & push
+      uses: docker/build-push-action@v4
+      with:
+        push: true
+        context: .
+        build-args: |
+          VERSION=${{ github.ref_name }}
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
# What has changed?

Add GitHub action to build and push the container image to `ghcr.io`.