### PR TITLE
TRIVIAL add step to generate metadata for build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
     - name: Docker build & push
       uses: docker/build-push-action@v4
       with:


### PR DESCRIPTION
# What has changed?

Add a release step to get metadata for the build phase.